### PR TITLE
Fix how guids are cleaned

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,6 +261,10 @@ const CLEAN = exports.CLEAN = {
     return string
   }
 
+  guid: function (string) {
+    return string
+  }
+
 }
 
 const cleanDefault = exports.cleanDefault = function (node) {

--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ const CLEAN = exports.CLEAN = {
 
   imageURL: function (string) {
     return string
-  }
+  },
 
   guid: function (string) {
     return string

--- a/test/test.js
+++ b/test/test.js
@@ -148,7 +148,7 @@ describe('Checking custom options', function () {
     const options = {
       fields : {
         'meta': ['default', 'webMaster'],
-        'episodes': ['default', 'timeline']
+        'episodes': ['default', 'timeline', 'guid']
       }
     }
     const podcast = podcastFeedParser.getPodcastFromFeed(sampleFeed, options)
@@ -158,6 +158,7 @@ describe('Checking custom options', function () {
     expect(podcast.episodes[0]).to.be.an('object').that.contains.keys('title', 'description', 'subtitle', 'imageURL', 'pubDate',
         'link', 'language', 'enclosure', 'duration', 'summary', 'blocked',
         'explicit', 'order', 'timeline')
+    expect(podcast.episodes[0].guid).to.equal('9a7e7418443444538633719efdfbe7fa')
   })
 
   it('should return object with only given custom fields', function() {


### PR DESCRIPTION
Currently, guids are cleaned so that only the first character is returned (`9a7e7418443444538633719efdfbe7fa` to `9` for example). I've added a function to stop this and a test.