### PR TITLE
Owner clean function breaks when either name or email is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,10 +217,17 @@ const CLEAN = exports.CLEAN = {
   },
 
   owner: function (object) {
-    return {
-      name: object[0]["itunes:name"][0],
-      email: object[0]["itunes:email"][0]
+    let ownerObject = {}
+
+    if (object[0].hasOwnProperty("itunes:name")) {
+      ownerObject.name = object[0]["itunes:name"][0]
     }
+
+    if (object[0].hasOwnProperty("itunes:email")) {
+      ownerObject.email = object[0]["itunes:email"][0]
+    }
+
+    return ownerObject
   },
 
   lastUpdated: function (string) {


### PR DESCRIPTION
I ran into this on about half of the podcasts I was trying to add. Simple fix by making both the email and the name optional.