### PR TITLE
Fixed recursive fetch when new url is unchanged

### DIFF
--- a/index.js
+++ b/index.js
@@ -443,8 +443,10 @@ const getPodcastFromURL = exports.getPodcastFromURL = async function (url, param
     const feedResponse = await fetchFeed(url)
     const channel = feedResponse.rss.channel[0]
 
-    if (channel["itunes:new-feed-url"]) {
-      return await getPodcastFromURL(channel["itunes:new-feed-url"][0], params)
+    const newURL = channel["itunes:new-feed-url"][0]
+
+    if (newURL && newURL != url) {
+      return await getPodcastFromURL(newUrl, params)
     }
 
     const meta = createMetaObjectFromFeed(channel, options)

--- a/index.js
+++ b/index.js
@@ -446,7 +446,7 @@ const getPodcastFromURL = exports.getPodcastFromURL = async function (url, param
     const newURL = channel["itunes:new-feed-url"][0]
 
     if (newURL && newURL != url) {
-      return await getPodcastFromURL(newUrl, params)
+      return await getPodcastFromURL(newURL, params)
     }
 
     const meta = createMetaObjectFromFeed(channel, options)

--- a/index.js
+++ b/index.js
@@ -443,7 +443,7 @@ const getPodcastFromURL = exports.getPodcastFromURL = async function (url, param
     const feedResponse = await fetchFeed(url)
     const channel = feedResponse.rss.channel[0]
 
-    const newURL = channel["itunes:new-feed-url"][0]
+    const newURL = channel?.["itunes:new-feed-url"]?.[0]
 
     if (newURL && newURL != url) {
       return await getPodcastFromURL(newURL, params)


### PR DESCRIPTION
As is, the script will infinitely fetch [this podcast](https://rss.art19.com/world-news-roundup)  this pr will fix that