### PR TITLE
Fix categories map on undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
-const fetch = require("isomorphic-fetch");
-const parseString = require("xml2js").parseString;
+const fetch = require('isomorphic-fetch')
+const parseString = require('xml2js').parseString
 
-const ERRORS = (exports.ERRORS = {
-  parsingError: new Error("Parsing error."),
-  requiredError: new Error(
-    "One or more required values are missing from feed."
-  ),
-  fetchingError: new Error("Fetching error."),
-  optionsError: new Error("Invalid options."),
-});
+const ERRORS = exports.ERRORS = {
+  'parsingError' : new Error("Parsing error."),
+  'requiredError' : new Error("One or more required values are missing from feed."),
+  'fetchingError' : new Error("Fetching error."),
+  'optionsError' : new Error("Invalid options.")
+}
 
 /*
 ============================================
@@ -16,145 +14,87 @@ const ERRORS = (exports.ERRORS = {
 ============================================
 */
 
-const DEFAULT = (exports.DEFAULT = {
+const DEFAULT = exports.DEFAULT = {
   fields: {
-    meta: [
-      "title",
-      "description",
-      "subtitle",
-      "imageURL",
-      "lastUpdated",
-      "link",
-      "language",
-      "editor",
-      "author",
-      "summary",
-      "categories",
-      "owner",
-      "explicit",
-      "complete",
-      "blocked",
-    ],
-    episodes: [
-      "title",
-      "description",
-      "subtitle",
-      "imageURL",
-      "pubDate",
-      "link",
-      "language",
-      "enclosure",
-      "duration",
-      "summary",
-      "blocked",
-      "explicit",
-      "order",
-    ],
+    meta: ['title', 'description', 'subtitle', 'imageURL', 'lastUpdated', 'link',
+            'language', 'editor', 'author', 'summary', 'categories', 'owner',
+            'explicit', 'complete', 'blocked'],
+    episodes: ['title', 'description', 'subtitle', 'imageURL', 'pubDate',
+            'link', 'language', 'enclosure', 'duration', 'summary', 'blocked',
+            'explicit', 'order']
   },
   required: {
     meta: [],
-    episodes: [],
+    episodes: []
   },
   uncleaned: {
     meta: [],
-    episodes: [],
-  },
-});
+    episodes: []
+  }
+}
 
 // from https://stackoverflow.com/questions/1584370/how-to-merge-two-arrays-in-javascript-and-de-duplicate-items
-function mergeDedupe(arr) {
+function mergeDedupe(arr)
+{
   return [...new Set([].concat(...arr))];
 }
 
-const buildOptions = (exports.buildOptions = function (params) {
+const buildOptions = exports.buildOptions = function (params) {
   try {
+
     // default options
     // tried to accomplish this by referencing the DEFAULT object,
     // but ran into problems with mutation when doing Object.assign(options[key], params[key])
     let options = {
       fields: {
-        meta: [
-          "title",
-          "description",
-          "subtitle",
-          "imageURL",
-          "lastUpdated",
-          "link",
-          "language",
-          "editor",
-          "author",
-          "summary",
-          "categories",
-          "owner",
-          "explicit",
-          "complete",
-          "blocked",
-        ],
-        episodes: [
-          "title",
-          "description",
-          "subtitle",
-          "imageURL",
-          "pubDate",
-          "link",
-          "language",
-          "enclosure",
-          "duration",
-          "summary",
-          "blocked",
-          "explicit",
-          "order",
-        ],
+        meta: ['title', 'description', 'subtitle', 'imageURL', 'lastUpdated', 'link',
+                'language', 'editor', 'author', 'summary', 'categories', 'owner',
+                'explicit', 'complete', 'blocked'],
+        episodes: ['title', 'description', 'subtitle', 'imageURL', 'pubDate',
+                'link', 'language', 'enclosure', 'duration', 'summary', 'blocked',
+                'explicit', 'order']
       },
       required: {
         meta: [],
-        episodes: [],
+        episodes: []
       },
       uncleaned: {
         meta: [],
-        episodes: [],
-      },
-    };
+        episodes: []
+      }
+    }
 
     // if no options parameters given, use default
-    if (typeof params === "undefined") {
-      options = DEFAULT;
-      return options;
+    if (typeof params === 'undefined') {
+      options = DEFAULT
+      return options
     }
 
     // merge empty options and given options
-    Object.keys(options).forEach((key) => {
+    Object.keys(options).forEach( key => {
       if (params[key] !== undefined) {
-        Object.assign(options[key], params[key]);
+        Object.assign(options[key], params[key])
       }
-    });
+    })
 
     // if 'default' given in parameters, merge default options with given custom options
     //  and dedupe
-    if (options.fields.meta.indexOf("default") >= 0) {
-      options.fields.meta = mergeDedupe([
-        DEFAULT.fields.meta,
-        params.fields.meta,
-      ]);
-      options.fields.meta.splice(options.fields.meta.indexOf("default"), 1);
+    if (options.fields.meta.indexOf('default') >= 0) {
+      options.fields.meta = mergeDedupe([DEFAULT.fields.meta, params.fields.meta])
+      options.fields.meta.splice(options.fields.meta.indexOf('default'), 1)
     }
 
-    if (options.fields.episodes.indexOf("default") >= 0) {
-      options.fields.episodes = mergeDedupe([
-        DEFAULT.fields.episodes,
-        params.fields.episodes,
-      ]);
-      options.fields.episodes.splice(
-        options.fields.episodes.indexOf("default"),
-        1
-      );
+    if (options.fields.episodes.indexOf('default') >= 0) {
+      options.fields.episodes = mergeDedupe([DEFAULT.fields.episodes, params.fields.episodes])
+      options.fields.episodes.splice(options.fields.episodes.indexOf('default'), 1)
     }
 
-    return options;
+    return options
+
   } catch (err) {
-    throw ERRORS.optionsError;
+    throw ERRORS.optionsError
   }
-});
+}
 
 /*
 =====================
@@ -162,65 +102,66 @@ const buildOptions = (exports.buildOptions = function (params) {
 =====================
 */
 
-const GET = (exports.GET = {
+const GET = exports.GET = {
   imageURL: function (node) {
+
     if (node.image) {
-      return node.image[0].url[0];
+      return node.image[0].url[0]
     }
 
     if (node["itunes:image"]) {
-      return node["itunes:image"][0]["$"].href;
+      return node["itunes:image"][0]['$'].href
     }
 
-    return undefined;
+    return undefined
   },
 
   subtitle: function (node) {
-    return node["itunes:subtitle"];
+    return node['itunes:subtitle']
   },
 
   lastUpdated: function (node) {
-    return node.lastBuildDate;
+    return node.lastBuildDate
   },
 
   editor: function (node) {
-    return node.managingEditor;
+    return node.managingEditor
   },
 
   author: function (node) {
-    return node["itunes:author"];
+    return node['itunes:author']
   },
 
   summary: function (node) {
-    return node["itunes:summary"];
+    return node['itunes:summary']
   },
 
   owner: function (node) {
-    return node["itunes:owner"];
+    return node['itunes:owner']
   },
 
   explicit: function (node) {
-    return node["itunes:explicit"];
+    return node['itunes:explicit']
   },
 
   complete: function (node) {
-    return node["itunes:complete"];
+    return node['itunes:complete']
   },
 
   blocked: function (node) {
-    return node["itunes:block"];
+    return node['itunes:block']
   },
 
   order: function (node) {
-    return node["itunes:order"];
+    return node['itunes:order']
   },
 
   guid: function (node) {
-    return node.guid[0]._;
+    return node.guid[0]._
   },
 
   duration: function (node) {
-    return node["itunes:duration"];
+    return node['itunes:duration']
   },
 
   categories: function (node) {
@@ -229,25 +170,25 @@ const GET = (exports.GET = {
     // of an array.
 
     let categoriesArray = [];
-    if (node["itunes:category"] && node["itunes:category"].length > 0) {
-      categoriesArray = node["itunes:category"].map((item) => {
-        let category = [];
-        category.push(item["$"].text); // primary category
-        if (item["itunes:category"]) {
-          // sub-category
-          category.push(item["itunes:category"][0]["$"].text);
+    if(node["itunes:category"] && node["itunes:category"].length > 0){
+      categoriesArray = node["itunes:category"].map( item => {
+        let category = []
+        category.push(item['$'].text) // primary category
+        if (item['itunes:category']) { // sub-category
+          category.push(item['itunes:category'][0]['$'].text)
         }
-        return category;
-      });
+        return category
+      })
     }
 
-    return categoriesArray;
-  },
-});
+    return categoriesArray
+  }
+}
 
-const getDefault = (exports.getDefault = function (node, field) {
-  return node[field] ? node[field] : undefined;
-});
+const getDefault = exports.getDefault = function (node, field) {
+  return (node[field]) ? node[field] : undefined
+}
+
 
 /*
 =======================
@@ -255,90 +196,91 @@ const getDefault = (exports.getDefault = function (node, field) {
 =======================
 */
 
-const CLEAN = (exports.CLEAN = {
+const CLEAN = exports.CLEAN = {
+
   enclosure: function (object) {
     return {
       length: object[0]["$"].length,
       type: object[0]["$"].type,
-      url: object[0]["$"].url,
-    };
+      url: object[0]["$"].url
+    }
   },
 
   duration: function (string) {
     // gives duration in seconds
-    let times = string[0].split(":"),
-      sum = 0,
-      mul = 1;
+    let times = string[0].split(':'),
+    sum = 0, mul = 1
 
     while (times.length > 0) {
-      sum += mul * parseInt(times.pop());
-      mul *= 60;
+      sum += mul * parseInt(times.pop())
+      mul *= 60
     }
 
-    return sum;
+    return sum
   },
 
   owner: function (object) {
-    let ownerObject = {};
+    let ownerObject = {}
 
     if (object[0].hasOwnProperty("itunes:name")) {
-      ownerObject.name = object[0]["itunes:name"][0];
+      ownerObject.name = object[0]["itunes:name"][0]
     }
 
     if (object[0].hasOwnProperty("itunes:email")) {
-      ownerObject.email = object[0]["itunes:email"][0];
+      ownerObject.email = object[0]["itunes:email"][0]
     }
 
-    return ownerObject;
+    return ownerObject
   },
 
   lastUpdated: function (string) {
-    return new Date(string).toISOString();
+    return new Date(string).toISOString()
   },
 
   pubDate: function (string) {
-    return new Date(string).toISOString();
+    return new Date(string).toISOString()
   },
 
   complete: function (string) {
-    if (string[0].toLowerCase == "yes") {
-      return true;
+    if (string[0].toLowerCase == 'yes') {
+      return true
     } else {
-      return false;
+      return false
     }
   },
 
   blocked: function (string) {
-    if (string.toLowerCase == "yes") {
-      return true;
+    if (string.toLowerCase == 'yes') {
+      return true
     } else {
-      return false;
+      return false
     }
   },
 
   explicit: function (string) {
-    if (["yes", "explicit", "true"].indexOf(string[0].toLowerCase()) >= 0) {
-      return true;
-    } else if (["clean", "no", "false"].indexOf(string[0].toLowerCase()) >= 0) {
-      return false;
+    if (['yes', 'explicit', 'true'].indexOf(string[0].toLowerCase()) >= 0) {
+      return true
+    } else if (['clean', 'no', 'false'].indexOf(string[0].toLowerCase()) >= 0) {
+      return false
     } else {
-      return undefined;
+      return undefined
     }
   },
 
   imageURL: function (string) {
-    return string;
-  },
-});
-
-const cleanDefault = (exports.cleanDefault = function (node) {
-  // return first item of array
-  if (node !== undefined && node[0] !== undefined) {
-    return node[0];
-  } else {
-    return node;
+    return string
   }
-});
+
+}
+
+const cleanDefault = exports.cleanDefault = function (node) {
+  // return first item of array
+  if (node !== undefined && node[0]!== undefined) {
+    return node[0]
+  } else {
+    return node
+  }
+}
 
 /*
 =================================
@@ -346,7 +288,7 @@ const cleanDefault = (exports.cleanDefault = function (node) {
 =================================
 */
 
-const getInfo = (exports.getInfo = function (node, field, uncleaned) {
+const getInfo = exports.getInfo = function (node, field, uncleaned) {
   // gets relevant info from podcast feed using options:
   // @field - string - the desired field name, corresponding with GET and clean
   //     functions
@@ -356,98 +298,101 @@ const getInfo = (exports.getInfo = function (node, field, uncleaned) {
 
   // if field has a GET function, use that
   // if not, get default value
-  info = GET[field] ? GET[field].call(this, node) : getDefault(node, field);
+  info = (GET[field]) ? GET[field].call(this, node) : getDefault(node,field)
 
   // if field is not marked as uncleaned, clean it using CLEAN functions
   if (!uncleaned && info !== undefined) {
-    info = CLEAN[field] ? CLEAN[field].call(this, info) : cleanDefault(info);
+    info = (CLEAN[field]) ? CLEAN[field].call(this, info) : cleanDefault(info)
   } else {
   }
 
-  return info;
-});
+  return info
+}
 
-function createMetaObjectFromFeed(channel, options) {
-  const meta = {};
+function createMetaObjectFromFeed (channel, options) {
 
-  options.fields.meta.forEach((field) => {
-    const obj = {};
-    var uncleaned = false;
+  const meta = {}
+
+  options.fields.meta.forEach( (field) => {
+    const obj = {}
+    var uncleaned = false
 
     if (options.uncleaned && options.uncleaned.meta) {
-      var uncleaned = options.uncleaned.meta.indexOf(field) >= 0;
+      var uncleaned = (options.uncleaned.meta.indexOf(field) >= 0)
     }
 
-    obj[field] = getInfo(channel, field, uncleaned);
+    obj[field] = getInfo(channel, field, uncleaned)
 
-    Object.assign(meta, obj);
-  });
+    Object.assign(meta, obj)
+  })
 
   if (options.required && options.required.meta) {
-    options.required.meta.forEach((field) => {
+    options.required.meta.forEach( (field) => {
       if (Object.keys(meta).indexOf(field) < 0) {
-        throw ERRORS.requiredError;
+        throw ERRORS.requiredError
       }
-    });
+    })
   }
 
-  return meta;
+  return meta
 }
 
 // function builds episode objects from parsed podcast feed
-function createEpisodesObjectFromFeed(channel, options) {
-  let episodes = [];
+function createEpisodesObjectFromFeed (channel, options) {
+  let episodes = []
 
-  channel.item.forEach((item) => {
-    const episode = {};
+  channel.item.forEach( (item) => {
+    const episode = {}
 
-    options.fields.episodes.forEach((field) => {
-      const obj = {};
-      var uncleaned = false;
+    options.fields.episodes.forEach( (field) => {
+      const obj = {}
+      var uncleaned = false
 
       if (options.uncleaned && options.uncleaned.episodes) {
-        var uncleaned = options.uncleaned.episodes.indexOf(field) >= 0;
+        var uncleaned = (options.uncleaned.episodes.indexOf(field) >= 0)
       }
 
-      obj[field] = getInfo(item, field, uncleaned);
+      obj[field] = getInfo(item, field, uncleaned)
 
-      Object.assign(episode, obj);
-    });
+      Object.assign(episode, obj)
+    })
 
     if (options.required && options.required.episodes) {
-      options.required.episodes.forEach((field) => {
+      options.required.episodes.forEach( (field) => {
         if (Object.keys(episode).indexOf(field) < 0) {
-          throw ERRORS.requiredError;
+          throw ERRORS.requiredError
         }
-      });
+      })
     }
 
-    episodes.push(episode);
-  });
+    episodes.push(episode)
+  })
 
-  episodes.sort(function (a, b) {
-    // sorts by order first, if defined, then sorts by date.
-    // if multiple episodes were published at the same time,
-    // they are then sorted by title
-    if (a.order == b.order) {
-      if (a.pubDate == b.pubDate) {
-        return a.title > b.title ? -1 : 1;
+  episodes.sort(
+    function (a, b) {
+      // sorts by order first, if defined, then sorts by date.
+      // if multiple episodes were published at the same time,
+      // they are then sorted by title
+      if (a.order == b.order) {
+        if (a.pubDate == b.pubDate) {
+          return a.title > b.title ? -1 : 1
+        }
+        return b.pubDate > a.pubDate ? 1 : -1
       }
-      return b.pubDate > a.pubDate ? 1 : -1;
+
+      if (a.order && !b.order) {
+        return 1
+      }
+
+      if (b.order && !a.order) {
+        return -1
+      }
+
+      return a.order > b.order ? -1 : 1
     }
+  )
 
-    if (a.order && !b.order) {
-      return 1;
-    }
-
-    if (b.order && !a.order) {
-      return -1;
-    }
-
-    return a.order > b.order ? -1 : 1;
-  });
-
-  return episodes;
+  return episodes
 }
 
 /*
@@ -456,37 +401,35 @@ function createEpisodesObjectFromFeed(channel, options) {
 ======================
 */
 
-function promiseParseXMLFeed(feedText) {
+function promiseParseXMLFeed (feedText) {
   return new Promise((resolve, reject) => {
+        parseString(feedText, (error, result) => {
+            if (error) { reject(ERRORS.parsingError) }
+            resolve(result)
+        })
+    })
+}
+
+function parseXMLFeed (feedText) {
+    let feed = {}
     parseString(feedText, (error, result) => {
       if (error) {
-        reject(ERRORS.parsingError);
+        throw ERRORS.parsingError
       }
-      resolve(result);
-    });
-  });
+      Object.assign(feed, result)
+      return result
+    })
+    return (feed)
 }
 
-function parseXMLFeed(feedText) {
-  let feed = {};
-  parseString(feedText, (error, result) => {
-    if (error) {
-      throw ERRORS.parsingError;
-    }
-    Object.assign(feed, result);
-    return result;
-  });
-  return feed;
-}
-
-async function fetchFeed(url) {
+async function fetchFeed (url) {
   try {
-    const feedResponse = await fetch(url);
-    const feedText = await feedResponse.text();
-    const feedObject = await promiseParseXMLFeed(feedText);
-    return feedObject;
+    const feedResponse = await fetch(url)
+    const feedText = await feedResponse.text()
+    const feedObject = await promiseParseXMLFeed(feedText)
+    return feedObject
   } catch (err) {
-    throw ERRORS.fetchingError;
+    throw ERRORS.fetchingError
   }
 }
 
@@ -496,50 +439,44 @@ async function fetchFeed(url) {
 =======================
 */
 
-const getPodcastFromURL = (exports.getPodcastFromURL = async function (
-  url,
-  params
-) {
+const getPodcastFromURL = exports.getPodcastFromURL = async function (url, params) {
   try {
-    const options = buildOptions(params);
+    const options = buildOptions(params)
 
-    const feedResponse = await fetchFeed(url);
-    const channel = feedResponse.rss.channel[0];
+    const feedResponse = await fetchFeed(url)
+    const channel = feedResponse.rss.channel[0]
 
     if (channel["itunes:new-feed-url"]) {
-      return await getPodcastFromURL(channel["itunes:new-feed-url"][0], params);
+      return await getPodcastFromURL(channel["itunes:new-feed-url"][0], params)
     }
 
-    const meta = createMetaObjectFromFeed(channel, options);
-    const episodes = createEpisodesObjectFromFeed(channel, options);
+    const meta = createMetaObjectFromFeed(channel, options)
+    const episodes = createEpisodesObjectFromFeed(channel, options)
 
-    return { meta, episodes };
-  } catch (err) {
-    throw err;
+    return {meta, episodes}
   }
-});
+  catch (err) {
+    throw err
+  }
+}
 
-const getPodcastFromFeed = (exports.getPodcastFromFeed = function (
-  feed,
-  params
-) {
+const getPodcastFromFeed = exports.getPodcastFromFeed = function (feed, params) {
   try {
-    const options = buildOptions(params);
+    const options = buildOptions(params)
 
-    const feedObject = parseXMLFeed(feed);
-    const channel = feedObject.rss.channel[0];
+    const feedObject = parseXMLFeed(feed)
+    const channel = feedObject.rss.channel[0]
 
     if (channel["itunes:new-feed-url"]) {
-      console.warn(
-        "\nWarning: Feed includes <itunes:new-feed-url> element, which indicates that the feed being parsed may be outdated.\n"
-      );
+      console.warn("\nWarning: Feed includes \<itunes:new-feed-url\> element, which indicates that the feed being parsed may be outdated.\n")
     }
 
-    const meta = createMetaObjectFromFeed(channel, options);
-    const episodes = createEpisodesObjectFromFeed(channel, options);
+    const meta = createMetaObjectFromFeed(channel, options)
+    const episodes = createEpisodesObjectFromFeed(channel, options)
 
-    return { meta, episodes };
-  } catch (err) {
-    throw err;
+    return {meta, episodes}
   }
-});
+  catch (err) {
+    throw err
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
-const fetch = require('isomorphic-fetch')
-const parseString = require('xml2js').parseString
+const fetch = require("isomorphic-fetch");
+const parseString = require("xml2js").parseString;
 
-const ERRORS = exports.ERRORS = {
-  'parsingError' : new Error("Parsing error."),
-  'requiredError' : new Error("One or more required values are missing from feed."),
-  'fetchingError' : new Error("Fetching error."),
-  'optionsError' : new Error("Invalid options.")
-}
+const ERRORS = (exports.ERRORS = {
+  parsingError: new Error("Parsing error."),
+  requiredError: new Error(
+    "One or more required values are missing from feed."
+  ),
+  fetchingError: new Error("Fetching error."),
+  optionsError: new Error("Invalid options."),
+});
 
 /*
 ============================================
@@ -14,87 +16,145 @@ const ERRORS = exports.ERRORS = {
 ============================================
 */
 
-const DEFAULT = exports.DEFAULT = {
+const DEFAULT = (exports.DEFAULT = {
   fields: {
-    meta: ['title', 'description', 'subtitle', 'imageURL', 'lastUpdated', 'link',
-            'language', 'editor', 'author', 'summary', 'categories', 'owner',
-            'explicit', 'complete', 'blocked'],
-    episodes: ['title', 'description', 'subtitle', 'imageURL', 'pubDate',
-            'link', 'language', 'enclosure', 'duration', 'summary', 'blocked',
-            'explicit', 'order']
+    meta: [
+      "title",
+      "description",
+      "subtitle",
+      "imageURL",
+      "lastUpdated",
+      "link",
+      "language",
+      "editor",
+      "author",
+      "summary",
+      "categories",
+      "owner",
+      "explicit",
+      "complete",
+      "blocked",
+    ],
+    episodes: [
+      "title",
+      "description",
+      "subtitle",
+      "imageURL",
+      "pubDate",
+      "link",
+      "language",
+      "enclosure",
+      "duration",
+      "summary",
+      "blocked",
+      "explicit",
+      "order",
+    ],
   },
   required: {
     meta: [],
-    episodes: []
+    episodes: [],
   },
   uncleaned: {
     meta: [],
-    episodes: []
-  }
-}
+    episodes: [],
+  },
+});
 
 // from https://stackoverflow.com/questions/1584370/how-to-merge-two-arrays-in-javascript-and-de-duplicate-items
-function mergeDedupe(arr)
-{
+function mergeDedupe(arr) {
   return [...new Set([].concat(...arr))];
 }
 
-const buildOptions = exports.buildOptions = function (params) {
+const buildOptions = (exports.buildOptions = function (params) {
   try {
-
     // default options
     // tried to accomplish this by referencing the DEFAULT object,
     // but ran into problems with mutation when doing Object.assign(options[key], params[key])
     let options = {
       fields: {
-        meta: ['title', 'description', 'subtitle', 'imageURL', 'lastUpdated', 'link',
-                'language', 'editor', 'author', 'summary', 'categories', 'owner',
-                'explicit', 'complete', 'blocked'],
-        episodes: ['title', 'description', 'subtitle', 'imageURL', 'pubDate',
-                'link', 'language', 'enclosure', 'duration', 'summary', 'blocked',
-                'explicit', 'order']
+        meta: [
+          "title",
+          "description",
+          "subtitle",
+          "imageURL",
+          "lastUpdated",
+          "link",
+          "language",
+          "editor",
+          "author",
+          "summary",
+          "categories",
+          "owner",
+          "explicit",
+          "complete",
+          "blocked",
+        ],
+        episodes: [
+          "title",
+          "description",
+          "subtitle",
+          "imageURL",
+          "pubDate",
+          "link",
+          "language",
+          "enclosure",
+          "duration",
+          "summary",
+          "blocked",
+          "explicit",
+          "order",
+        ],
       },
       required: {
         meta: [],
-        episodes: []
+        episodes: [],
       },
       uncleaned: {
         meta: [],
-        episodes: []
-      }
-    }
+        episodes: [],
+      },
+    };
 
     // if no options parameters given, use default
-    if (typeof params === 'undefined') {
-      options = DEFAULT
-      return options
+    if (typeof params === "undefined") {
+      options = DEFAULT;
+      return options;
     }
 
     // merge empty options and given options
-    Object.keys(options).forEach( key => {
+    Object.keys(options).forEach((key) => {
       if (params[key] !== undefined) {
-        Object.assign(options[key], params[key])
+        Object.assign(options[key], params[key]);
       }
-    })
+    });
 
     // if 'default' given in parameters, merge default options with given custom options
     //  and dedupe
-    if (options.fields.meta.indexOf('default') >= 0) {
-      options.fields.meta = mergeDedupe([DEFAULT.fields.meta, params.fields.meta])
-      options.fields.meta.splice(options.fields.meta.indexOf('default'), 1)
+    if (options.fields.meta.indexOf("default") >= 0) {
+      options.fields.meta = mergeDedupe([
+        DEFAULT.fields.meta,
+        params.fields.meta,
+      ]);
+      options.fields.meta.splice(options.fields.meta.indexOf("default"), 1);
     }
 
-    if (options.fields.episodes.indexOf('default') >= 0) {
-      options.fields.episodes = mergeDedupe([DEFAULT.fields.episodes, params.fields.episodes])
-      options.fields.episodes.splice(options.fields.episodes.indexOf('default'), 1)
+    if (options.fields.episodes.indexOf("default") >= 0) {
+      options.fields.episodes = mergeDedupe([
+        DEFAULT.fields.episodes,
+        params.fields.episodes,
+      ]);
+      options.fields.episodes.splice(
+        options.fields.episodes.indexOf("default"),
+        1
+      );
     }
 
-    return options
-
+    return options;
   } catch (err) {
-    throw ERRORS.optionsError
+    throw ERRORS.optionsError;
   }
-}
+});
 
 /*
 =====================
@@ -102,66 +162,65 @@ const buildOptions = exports.buildOptions = function (params) {
 =====================
 */
 
-const GET = exports.GET = {
+const GET = (exports.GET = {
   imageURL: function (node) {
-
     if (node.image) {
-      return node.image[0].url[0]
+      return node.image[0].url[0];
     }
 
     if (node["itunes:image"]) {
-      return node["itunes:image"][0]['$'].href
+      return node["itunes:image"][0]["$"].href;
     }
 
-    return undefined
+    return undefined;
   },
 
   subtitle: function (node) {
-    return node['itunes:subtitle']
+    return node["itunes:subtitle"];
   },
 
   lastUpdated: function (node) {
-    return node.lastBuildDate
+    return node.lastBuildDate;
   },
 
   editor: function (node) {
-    return node.managingEditor
+    return node.managingEditor;
   },
 
   author: function (node) {
-    return node['itunes:author']
+    return node["itunes:author"];
   },
 
   summary: function (node) {
-    return node['itunes:summary']
+    return node["itunes:summary"];
   },
 
   owner: function (node) {
-    return node['itunes:owner']
+    return node["itunes:owner"];
   },
 
   explicit: function (node) {
-    return node['itunes:explicit']
+    return node["itunes:explicit"];
   },
 
   complete: function (node) {
-    return node['itunes:complete']
+    return node["itunes:complete"];
   },
 
   blocked: function (node) {
-    return node['itunes:block']
+    return node["itunes:block"];
   },
 
   order: function (node) {
-    return node['itunes:order']
+    return node["itunes:order"];
   },
 
   guid: function (node) {
-    return node.guid[0]._
+    return node.guid[0]._;
   },
 
   duration: function (node) {
-    return node['itunes:duration']
+    return node["itunes:duration"];
   },
 
   categories: function (node) {
@@ -169,23 +228,26 @@ const GET = exports.GET = {
     // grouping in lists. If there is a sub-category, it is the second element
     // of an array.
 
-    const categoriesArray = node["itunes:category"].map( item => {
-      let category = []
-      category.push(item['$'].text) // primary category
-      if (item['itunes:category']) { // sub-category
-        category.push(item['itunes:category'][0]['$'].text)
-      }
-      return category
-    })
+    let categoriesArray = [];
+    if (node["itunes:category"] && node["itunes:category"].length > 0) {
+      categoriesArray = node["itunes:category"].map((item) => {
+        let category = [];
+        category.push(item["$"].text); // primary category
+        if (item["itunes:category"]) {
+          // sub-category
+          category.push(item["itunes:category"][0]["$"].text);
+        }
+        return category;
+      });
+    }
 
-    return categoriesArray
-  }
-}
+    return categoriesArray;
+  },
+});
 
-const getDefault = exports.getDefault = function (node, field) {
-  return (node[field]) ? node[field] : undefined
-}
-
+const getDefault = (exports.getDefault = function (node, field) {
+  return node[field] ? node[field] : undefined;
+});
 
 /*
 =======================
@@ -193,91 +255,90 @@ const getDefault = exports.getDefault = function (node, field) {
 =======================
 */
 
-const CLEAN = exports.CLEAN = {
-
+const CLEAN = (exports.CLEAN = {
   enclosure: function (object) {
     return {
       length: object[0]["$"].length,
       type: object[0]["$"].type,
-      url: object[0]["$"].url
-    }
+      url: object[0]["$"].url,
+    };
   },
 
   duration: function (string) {
     // gives duration in seconds
-    let times = string[0].split(':'),
-    sum = 0, mul = 1
+    let times = string[0].split(":"),
+      sum = 0,
+      mul = 1;
 
     while (times.length > 0) {
-      sum += mul * parseInt(times.pop())
-      mul *= 60
+      sum += mul * parseInt(times.pop());
+      mul *= 60;
     }
 
-    return sum
+    return sum;
   },
 
   owner: function (object) {
-    let ownerObject = {}
+    let ownerObject = {};
 
     if (object[0].hasOwnProperty("itunes:name")) {
-      ownerObject.name = object[0]["itunes:name"][0]
+      ownerObject.name = object[0]["itunes:name"][0];
     }
 
     if (object[0].hasOwnProperty("itunes:email")) {
-      ownerObject.email = object[0]["itunes:email"][0]
+      ownerObject.email = object[0]["itunes:email"][0];
     }
 
-    return ownerObject
+    return ownerObject;
   },
 
   lastUpdated: function (string) {
-    return new Date(string).toISOString()
+    return new Date(string).toISOString();
   },
 
   pubDate: function (string) {
-    return new Date(string).toISOString()
+    return new Date(string).toISOString();
   },
 
   complete: function (string) {
-    if (string[0].toLowerCase == 'yes') {
-      return true
+    if (string[0].toLowerCase == "yes") {
+      return true;
     } else {
-      return false
+      return false;
     }
   },
 
   blocked: function (string) {
-    if (string.toLowerCase == 'yes') {
-      return true
+    if (string.toLowerCase == "yes") {
+      return true;
     } else {
-      return false
+      return false;
     }
   },
 
   explicit: function (string) {
-    if (['yes', 'explicit', 'true'].indexOf(string[0].toLowerCase()) >= 0) {
-      return true
-    } else if (['clean', 'no', 'false'].indexOf(string[0].toLowerCase()) >= 0) {
-      return false
+    if (["yes", "explicit", "true"].indexOf(string[0].toLowerCase()) >= 0) {
+      return true;
+    } else if (["clean", "no", "false"].indexOf(string[0].toLowerCase()) >= 0) {
+      return false;
     } else {
-      return undefined
+      return undefined;
     }
   },
 
   imageURL: function (string) {
-    return string
-  }
+    return string;
+  },
+});
 
-}
-
-const cleanDefault = exports.cleanDefault = function (node) {
+const cleanDefault = (exports.cleanDefault = function (node) {
   // return first item of array
-  if (node !== undefined && node[0]!== undefined) {
-    return node[0]
+  if (node !== undefined && node[0] !== undefined) {
+    return node[0];
   } else {
-    return node
+    return node;
   }
-}
+});
 
 /*
 =================================
@@ -285,7 +346,7 @@ const cleanDefault = exports.cleanDefault = function (node) {
 =================================
 */
 
-const getInfo = exports.getInfo = function (node, field, uncleaned) {
+const getInfo = (exports.getInfo = function (node, field, uncleaned) {
   // gets relevant info from podcast feed using options:
   // @field - string - the desired field name, corresponding with GET and clean
   //     functions
@@ -295,101 +356,98 @@ const getInfo = exports.getInfo = function (node, field, uncleaned) {
 
   // if field has a GET function, use that
   // if not, get default value
-  info = (GET[field]) ? GET[field].call(this, node) : getDefault(node,field)
+  info = GET[field] ? GET[field].call(this, node) : getDefault(node, field);
 
   // if field is not marked as uncleaned, clean it using CLEAN functions
   if (!uncleaned && info !== undefined) {
-    info = (CLEAN[field]) ? CLEAN[field].call(this, info) : cleanDefault(info)
+    info = CLEAN[field] ? CLEAN[field].call(this, info) : cleanDefault(info);
   } else {
   }
 
-  return info
-}
+  return info;
+});
 
-function createMetaObjectFromFeed (channel, options) {
+function createMetaObjectFromFeed(channel, options) {
+  const meta = {};
 
-  const meta = {}
-
-  options.fields.meta.forEach( (field) => {
-    const obj = {}
-    var uncleaned = false
+  options.fields.meta.forEach((field) => {
+    const obj = {};
+    var uncleaned = false;
 
     if (options.uncleaned && options.uncleaned.meta) {
-      var uncleaned = (options.uncleaned.meta.indexOf(field) >= 0)
+      var uncleaned = options.uncleaned.meta.indexOf(field) >= 0;
     }
 
-    obj[field] = getInfo(channel, field, uncleaned)
+    obj[field] = getInfo(channel, field, uncleaned);
 
-    Object.assign(meta, obj)
-  })
+    Object.assign(meta, obj);
+  });
 
   if (options.required && options.required.meta) {
-    options.required.meta.forEach( (field) => {
+    options.required.meta.forEach((field) => {
       if (Object.keys(meta).indexOf(field) < 0) {
-        throw ERRORS.requiredError
+        throw ERRORS.requiredError;
       }
-    })
+    });
   }
 
-  return meta
+  return meta;
 }
 
 // function builds episode objects from parsed podcast feed
-function createEpisodesObjectFromFeed (channel, options) {
-  let episodes = []
+function createEpisodesObjectFromFeed(channel, options) {
+  let episodes = [];
 
-  channel.item.forEach( (item) => {
-    const episode = {}
+  channel.item.forEach((item) => {
+    const episode = {};
 
-    options.fields.episodes.forEach( (field) => {
-      const obj = {}
-      var uncleaned = false
+    options.fields.episodes.forEach((field) => {
+      const obj = {};
+      var uncleaned = false;
 
       if (options.uncleaned && options.uncleaned.episodes) {
-        var uncleaned = (options.uncleaned.episodes.indexOf(field) >= 0)
+        var uncleaned = options.uncleaned.episodes.indexOf(field) >= 0;
       }
 
-      obj[field] = getInfo(item, field, uncleaned)
+      obj[field] = getInfo(item, field, uncleaned);
 
-      Object.assign(episode, obj)
-    })
+      Object.assign(episode, obj);
+    });
 
     if (options.required && options.required.episodes) {
-      options.required.episodes.forEach( (field) => {
+      options.required.episodes.forEach((field) => {
         if (Object.keys(episode).indexOf(field) < 0) {
-          throw ERRORS.requiredError
+          throw ERRORS.requiredError;
         }
-      })
+      });
     }
 
-    episodes.push(episode)
-  })
+    episodes.push(episode);
+  });
 
-  episodes.sort(
-    function (a, b) {
-      // sorts by order first, if defined, then sorts by date.
-      // if multiple episodes were published at the same time,
-      // they are then sorted by title
-      if (a.order == b.order) {
-        if (a.pubDate == b.pubDate) {
-          return a.title > b.title ? -1 : 1
-        }
-        return b.pubDate > a.pubDate ? 1 : -1
+  episodes.sort(function (a, b) {
+    // sorts by order first, if defined, then sorts by date.
+    // if multiple episodes were published at the same time,
+    // they are then sorted by title
+    if (a.order == b.order) {
+      if (a.pubDate == b.pubDate) {
+        return a.title > b.title ? -1 : 1;
       }
-
-      if (a.order && !b.order) {
-        return 1
-      }
-
-      if (b.order && !a.order) {
-        return -1
-      }
-
-      return a.order > b.order ? -1 : 1
+      return b.pubDate > a.pubDate ? 1 : -1;
     }
-  )
 
-  return episodes
+    if (a.order && !b.order) {
+      return 1;
+    }
+
+    if (b.order && !a.order) {
+      return -1;
+    }
+
+    return a.order > b.order ? -1 : 1;
+  });
+
+  return episodes;
 }
 
 /*
@@ -398,35 +456,37 @@ function createEpisodesObjectFromFeed (channel, options) {
 ======================
 */
 
-function promiseParseXMLFeed (feedText) {
+function promiseParseXMLFeed(feedText) {
   return new Promise((resolve, reject) => {
-        parseString(feedText, (error, result) => {
-            if (error) { reject(ERRORS.parsingError) }
-            resolve(result)
-        })
-    })
-}
-
-function parseXMLFeed (feedText) {
-    let feed = {}
     parseString(feedText, (error, result) => {
       if (error) {
-        throw ERRORS.parsingError
+        reject(ERRORS.parsingError);
       }
-      Object.assign(feed, result)
-      return result
-    })
-    return (feed)
+      resolve(result);
+    });
+  });
 }
 
-async function fetchFeed (url) {
+function parseXMLFeed(feedText) {
+  let feed = {};
+  parseString(feedText, (error, result) => {
+    if (error) {
+      throw ERRORS.parsingError;
+    }
+    Object.assign(feed, result);
+    return result;
+  });
+  return feed;
+}
+
+async function fetchFeed(url) {
   try {
-    const feedResponse = await fetch(url)
-    const feedText = await feedResponse.text()
-    const feedObject = await promiseParseXMLFeed(feedText)
-    return feedObject
+    const feedResponse = await fetch(url);
+    const feedText = await feedResponse.text();
+    const feedObject = await promiseParseXMLFeed(feedText);
+    return feedObject;
   } catch (err) {
-    throw ERRORS.fetchingError
+    throw ERRORS.fetchingError;
   }
 }
 
@@ -436,44 +496,50 @@ async function fetchFeed (url) {
 =======================
 */
 
-const getPodcastFromURL = exports.getPodcastFromURL = async function (url, params) {
+const getPodcastFromURL = (exports.getPodcastFromURL = async function (
+  url,
+  params
+) {
   try {
-    const options = buildOptions(params)
+    const options = buildOptions(params);
 
-    const feedResponse = await fetchFeed(url)
-    const channel = feedResponse.rss.channel[0]
+    const feedResponse = await fetchFeed(url);
+    const channel = feedResponse.rss.channel[0];
 
     if (channel["itunes:new-feed-url"]) {
-      return await getPodcastFromURL(channel["itunes:new-feed-url"][0], params)
+      return await getPodcastFromURL(channel["itunes:new-feed-url"][0], params);
     }
 
-    const meta = createMetaObjectFromFeed(channel, options)
-    const episodes = createEpisodesObjectFromFeed(channel, options)
+    const meta = createMetaObjectFromFeed(channel, options);
+    const episodes = createEpisodesObjectFromFeed(channel, options);
 
-    return {meta, episodes}
+    return { meta, episodes };
+  } catch (err) {
+    throw err;
   }
-  catch (err) {
-    throw err
-  }
-}
+});
 
-const getPodcastFromFeed = exports.getPodcastFromFeed = function (feed, params) {
+const getPodcastFromFeed = (exports.getPodcastFromFeed = function (
+  feed,
+  params
+) {
   try {
-    const options = buildOptions(params)
+    const options = buildOptions(params);
 
-    const feedObject = parseXMLFeed(feed)
-    const channel = feedObject.rss.channel[0]
+    const feedObject = parseXMLFeed(feed);
+    const channel = feedObject.rss.channel[0];
 
     if (channel["itunes:new-feed-url"]) {
-      console.warn("\nWarning: Feed includes \<itunes:new-feed-url\> element, which indicates that the feed being parsed may be outdated.\n")
+      console.warn(
+        "\nWarning: Feed includes <itunes:new-feed-url> element, which indicates that the feed being parsed may be outdated.\n"
+      );
     }
 
-    const meta = createMetaObjectFromFeed(channel, options)
-    const episodes = createEpisodesObjectFromFeed(channel, options)
+    const meta = createMetaObjectFromFeed(channel, options);
+    const episodes = createEpisodesObjectFromFeed(channel, options);
 
-    return {meta, episodes}
+    return { meta, episodes };
+  } catch (err) {
+    throw err;
   }
-  catch (err) {
-    throw err
-  }
-}
+});


### PR DESCRIPTION
I had a podcast feed, that was throwing a typeerror, because it tried to run .map on `node["itunes:category"]`.

So I've added a check and if it's undefined, it will skip the map.


Thanks for the package tho! I love it how customisable it is!