### PR TITLE
Return the correct guid for guid in all scenarios

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ const GET = exports.GET = {
   },
 
   guid: function (node) {
-    return node.guid[0]._
+    return node.guid && node.guid[0]
   },
 
   duration: function (node) {
@@ -239,6 +239,14 @@ const CLEAN = exports.CLEAN = {
 
   pubDate: function (string) {
     return new Date(string).toISOString()
+  },
+
+  guid: function (string) {
+    if (typeof string === 'object' && '_' in string) {
+      return string._
+    } else {
+      return string
+    }
   },
 
   complete: function (string) {


### PR DESCRIPTION
Guid's can have an `isPermaLink` attribute, but not all guid's have one, the XML parser, however, returns two very different kind of arrays:

```
[{ _: '6c30ff0525aa764af827ac86f039e133', '$': { isPermaLink: 'false' } }]
['http://podcasting.radionikkei.jp/podcasting/lr/lr-181205.mp3']
```

This fix will return the correct guid for both scenarios as well as the scenario for when there is no guid at all.