### PR TITLE
prioritise images from itunes over the node.images

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,13 +104,12 @@ const buildOptions = exports.buildOptions = function (params) {
 
 const GET = exports.GET = {
   imageURL: function (node) {
+    if (node["itunes:image"]) {
+      return node["itunes:image"][0]['$'].href
+    }
 
     if (node.image) {
       return node.image[0].url[0]
-    }
-
-    if (node["itunes:image"]) {
-      return node["itunes:image"][0]['$'].href
     }
 
     return undefined

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-feed-parser",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A highly customizable package for fetching and parsing podcast feeds into simple and manageable JavaScript objects. For use with node and in the browser.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As we were using the library, we found that somehow using the itunes images provides much better results on the feeds parsed.